### PR TITLE
Quote $CFLAGS in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/pear-pt.c])
 AC_CONFIG_HEADERS([src/config.h])
 
-if test -z $CFLAGS; then
+if test -z "$CFLAGS"; then
     CFLAGS='-O3'
 fi
 


### PR DESCRIPTION
When configuring pear 0.9.8 and specifying some CFLAGS, for example by running:

    ./configure CFLAGS='-pipe -I/opt/local/include'

this warning is emitted:

    ./configure: line 2874: test: too many arguments

The problem is that you haven't enclosed `$CFLAGS` in quotation marks on that line. This pull request fixes that.
